### PR TITLE
Align icons in car details screen

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarDetailWithIcon.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarDetailWithIcon.kt
@@ -1,5 +1,6 @@
 package com.tomerpacific.caridentifier.composable
 
+import android.view.View
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +9,7 @@ import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
@@ -22,12 +24,23 @@ fun CarDetailWithIcon(iconId: String,
                       content: String,
                       icon: @Composable () -> Unit) {
 
-    val annotatedString = buildAnnotatedString {
-        appendInlineContent(iconId, "[icon]")
-        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-            append(labelText)
+    val annotatedString = when (LocalContext.current.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+        true ->
+        buildAnnotatedString {
+            appendInlineContent(iconId, "[icon]")
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(labelText)
+            }
+            append(content)
         }
-        append(content)
+        false ->
+            buildAnnotatedString {
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(labelText)
+                }
+                append(content)
+                appendInlineContent(iconId, "[icon]")
+        }
     }
 
     val inlineTextContent = mapOf(

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarDetailWithIcon.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarDetailWithIcon.kt
@@ -10,17 +10,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 
 @Composable
 fun CarDetailWithIcon(iconId: String,
-                      text: String,
+                      labelText: String,
+                      content: String,
                       icon: @Composable () -> Unit) {
 
     val annotatedString = buildAnnotatedString {
-        append(text)
         appendInlineContent(iconId, "[icon]")
+        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+            append(labelText)
+        }
+        append(content)
     }
 
     val inlineTextContent = mapOf(
@@ -42,7 +49,9 @@ fun CarDetailWithIcon(iconId: String,
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
     ) {
-        Text(annotatedString, inlineContent = inlineTextContent, fontSize = 20.sp)
+        Text(annotatedString,
+            inlineContent = inlineTextContent,
+            fontSize = 20.sp)
     }
 
 

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -154,7 +154,7 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "safetyIcon",
-        labelText = "רמת אבזור בטיחות: ",
+        labelText = " רמת אבזור בטיחות: ",
         content = "${details.safetyFeatureLevel}/8"
     ) {
         Icon(

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -131,7 +131,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "keysIcon",
-        text = " בעלות נוכחית: ${details.ownership} "
+        labelText = " בעלות נוכחית: ",
+        content = details.ownership
     ) {
         Icon(
             painterResource(id = R.drawable.ic_key_icon),"Key Icon",
@@ -141,7 +142,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "fuelIcon",
-        text = " סוג דלק: ${details.fuelType} "
+        labelText = " סוג דלק: ",
+        content = details.fuelType
     ) {
         Icon(
             painterResource(id = R.drawable.ic_fuel_type), "Fuel Icon",
@@ -152,7 +154,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "safetyIcon",
-        text = " רמת אבזור בטיחות: ${details.safetyFeatureLevel} "
+        labelText = "רמת אבזור בטיחות: ",
+        content = "${details.safetyFeatureLevel}/8"
     ) {
         Icon(
             painterResource(id = R.drawable.ic_shield), "Safety Icon",
@@ -163,7 +166,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "pollutionIcon",
-        text = " רמת זיהום אוויר: ${details.pollutionLevel} "
+        labelText = " רמת זיהום אוויר: ",
+        content = "${details.pollutionLevel}/15"
     ) {
         Icon(
             painterResource(id = R.drawable.ic_car_alert), "Pollution Icon",
@@ -174,7 +178,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "paletteIcon",
-        text = " צבע: ${details.color} "
+        labelText = " צבע: ",
+        content = details.color
     ) {
         Icon(
             painterResource(id = R.drawable.ic_palette), "Palette Icon",
@@ -185,7 +190,8 @@ fun CarInformation(details: CarDetails) {
 
     CarDetailWithIcon(
         iconId = "roadIcon",
-        text = " עלה לכביש: ${details.firstOnRoadDate} "
+        labelText = " עלה לכביש: ",
+        content = details.firstOnRoadDate
     ) {
         Icon(
             painterResource(id = R.drawable.ic_road), "Road Icon",


### PR DESCRIPTION
Resolves #40 
This pull request includes several changes to the `CarDetailWithIcon` and `CarInformation` composable functions to improve the handling of text and icons, particularly for right-to-left (RTL) layout direction support.

Improvements to `CarDetailWithIcon` composable function:

* Added `LocalContext` import and modified the `CarDetailWithIcon` composable function to handle RTL layout direction by conditionally appending the icon and text content based on the layout direction.
* Changed the `text` parameter to `labelText` and `content` to better separate the label from the content text.

Updates to `CarInformation` composable function:

* Updated the `CarInformation` composable function to use the new `labelText` and `content` parameters in the `CarDetailWithIcon` function.