### PR TITLE
Add retry after timeout

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -36,8 +36,6 @@ import com.tomerpacific.caridentifier.R
 import com.tomerpacific.caridentifier.concatenateCarMakeAndModel
 import com.tomerpacific.caridentifier.model.CarDetails
 import com.tomerpacific.caridentifier.model.MainViewModel
-import com.tomerpacific.caridentifier.data.network.NO_INTERNET_CONNECTION_ERROR
-import com.tomerpacific.caridentifier.data.network.REQUEST_TIMEOUT_ERROR
 
 @Composable
 fun Details(mainViewModel: MainViewModel, serverError: String?) {
@@ -83,8 +81,7 @@ fun Details(mainViewModel: MainViewModel, serverError: String?) {
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold
             )
-            if (serverError == NO_INTERNET_CONNECTION_ERROR ||
-                serverError == REQUEST_TIMEOUT_ERROR) {
+            if (mainViewModel.shouldShowRetryRequestButton()) {
                 IconButton(onClick = {
                     mainViewModel.getCarDetails(context)
                 }) {

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -82,7 +82,8 @@ fun Details(mainViewModel: MainViewModel, serverError: String?) {
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold
             )
-            if (serverError == NO_INTERNET_CONNECTION_ERROR) {
+            if (serverError == NO_INTERNET_CONNECTION_ERROR ||
+                serverError.trim() == "Request timeout has expired") {
                 IconButton(onClick = {
                     mainViewModel.getCarDetails(context)
                 }) {

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -53,39 +53,44 @@ fun Details(mainViewModel: MainViewModel, serverError: String?) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = columnVerticalArrangement
     ) {
-        if (carDetails.value == null && serverError == null) {
-            LoaderAnimation(R.raw.license_plate_scan_animation)
-        } else if (carDetails.value != null) {
-            CarInformation(carDetails.value!!)
-        } else if (serverError != null) {
-            Image(
-                modifier = Modifier
-                    .size(200.dp)
-                    .border(
-                        BorderStroke(1.dp, Color.Black),
-                        CircleShape
-                    )
-                    .clip(CircleShape),
-                painter = painterResource(R.drawable.broken_car),
-                contentDescription = "broken car",
-            )
-            Spacer(modifier = Modifier.size(100.dp))
-            Text(text = " לא ניתן להשיג את פרטי הרכב. נסו שנית.",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                style = TextStyle(textDirection = TextDirection.Rtl)
-            )
-            Text(text = serverError,
-                textAlign = TextAlign.Center,
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold
-            )
-            if (mainViewModel.shouldShowRetryRequestButton()) {
-                IconButton(onClick = {
-                    mainViewModel.getCarDetails(context)
-                }) {
-                    Icon(imageVector = Icons.Default.Refresh, contentDescription = "Retry")
+        when (serverError) {
+            null -> {
+                if (carDetails.value == null) {
+                    LoaderAnimation(R.raw.license_plate_scan_animation)
+                } else {
+                    CarInformation(carDetails.value!!)
+                }
+            }
+            else -> {
+                Image(
+                    modifier = Modifier
+                        .size(200.dp)
+                        .border(
+                            BorderStroke(1.dp, Color.Black),
+                            CircleShape
+                        )
+                        .clip(CircleShape),
+                    painter = painterResource(R.drawable.broken_car),
+                    contentDescription = "broken car",
+                )
+                Spacer(modifier = Modifier.size(100.dp))
+                Text(text = " לא ניתן להשיג את פרטי הרכב. נסו שנית.",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    style = TextStyle(textDirection = TextDirection.Rtl)
+                )
+                Text(text = serverError,
+                    textAlign = TextAlign.Center,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                if (mainViewModel.shouldShowRetryRequestButton()) {
+                    IconButton(onClick = {
+                        mainViewModel.getCarDetails(context)
+                    }) {
+                        Icon(imageVector = Icons.Default.Refresh, contentDescription = "Retry")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -37,6 +37,7 @@ import com.tomerpacific.caridentifier.concatenateCarMakeAndModel
 import com.tomerpacific.caridentifier.model.CarDetails
 import com.tomerpacific.caridentifier.model.MainViewModel
 import com.tomerpacific.caridentifier.data.network.NO_INTERNET_CONNECTION_ERROR
+import com.tomerpacific.caridentifier.data.network.REQUEST_TIMEOUT_ERROR
 
 @Composable
 fun Details(mainViewModel: MainViewModel, serverError: String?) {
@@ -83,7 +84,7 @@ fun Details(mainViewModel: MainViewModel, serverError: String?) {
                 fontWeight = FontWeight.Bold
             )
             if (serverError == NO_INTERNET_CONNECTION_ERROR ||
-                serverError.trim() == "Request timeout has expired") {
+                serverError == REQUEST_TIMEOUT_ERROR) {
                 IconButton(onClick = {
                     mainViewModel.getCarDetails(context)
                 }) {

--- a/app/src/main/java/com/tomerpacific/caridentifier/data/network/ConnectivityObserver.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/data/network/ConnectivityObserver.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.core.content.getSystemService
 
 const val NO_INTERNET_CONNECTION_ERROR = "No internet connection"
+const val REQUEST_TIMEOUT_ERROR = "Request timeout has expired"
 class ConnectivityObserver(
     context: Context
 ) {

--- a/app/src/main/java/com/tomerpacific/caridentifier/model/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/model/MainViewModel.kt
@@ -107,10 +107,10 @@ class MainViewModel(private val sharedPreferences: SharedPreferences,
                                 it.subSequence(
                                     0,
                                     it.indexOf("[")
-                                ).toString()
+                                ).toString().trim()
                             }
 
-                            false -> exception.localizedMessage
+                            false -> exception.localizedMessage?.trim()
                         }
                     }
                 }

--- a/app/src/main/java/com/tomerpacific/caridentifier/model/MainViewModel.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/model/MainViewModel.kt
@@ -12,6 +12,7 @@ import com.tomerpacific.caridentifier.data.repository.CarDetailsRepository
 import com.tomerpacific.caridentifier.formatCarReviewResponse
 import com.tomerpacific.caridentifier.data.network.ConnectivityObserver
 import com.tomerpacific.caridentifier.data.network.NO_INTERNET_CONNECTION_ERROR
+import com.tomerpacific.caridentifier.data.network.REQUEST_TIMEOUT_ERROR
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -174,6 +175,11 @@ class MainViewModel(private val sharedPreferences: SharedPreferences,
                 }
             }
         }
+    }
+    
+    fun shouldShowRetryRequestButton(): Boolean {
+        return _serverError.value == NO_INTERNET_CONNECTION_ERROR ||
+                _serverError.value == REQUEST_TIMEOUT_ERROR
     }
 
     override fun onCleared() {


### PR DESCRIPTION
Resolves #38 
This pull request includes several changes to improve error handling and UI behavior in the `CarInformation` composable and related files. The most important changes include adding a new error constant, modifying the `Details` composable to handle different server errors, and adding a new method to the `MainViewModel` to determine when to show a retry button.

### Error Handling Improvements:
- Added a new error constant `REQUEST_TIMEOUT_ERROR` to handle request timeout errors.
- Imported the new `REQUEST_TIMEOUT_ERROR` constant and added a method `shouldShowRetryRequestButton()` to determine when to show a retry button based on the error type

### UI Behavior Enhancements:
- Modified the `Details` composable to use a `when` statement for handling different server errors and to show a retry button when appropriate

### Code Quality Improvements:
- Trimmed whitespace from exception messages to improve the readability of error messages.