### PR TITLE
CarIdentifier adding padding to title in main screen

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/screen/MainScreen.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/screen/MainScreen.kt
@@ -67,7 +67,7 @@ fun MainScreen(navController: NavController,
 private fun LicensePlateInputOptionsHeader() {
     Row(modifier = Modifier
         .fillMaxWidth()
-        .padding(top = 30.dp),
+        .padding(top = 30.dp, start = 10.dp, end = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center) {
         Text("בחר/י באפשרות לחפש פרטים בנוגע לרכב",


### PR DESCRIPTION
Fixes #47 

This pull request includes a small UI improvement to the `MainScreen.kt` file. The padding for the `LicensePlateInputOptionsHeader` component was updated to include `start` and `end` padding for better alignment and spacing.