### PR TITLE
Correcting internal escaping of car review response

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/Utilities.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/Utilities.kt
@@ -135,10 +135,14 @@ fun formatCarReviewResponse(carReview: String): CarReview {
     var isInProsSection = false
 
     carReviewLines.forEach { line ->
+        val formattedLine = when (line.contains("\\")) {
+            true -> line.replace("\\", "")
+            false -> line
+        }
         when {
-            line.contains(PROS, true) -> isInProsSection = true
-            line.contains(CONS, true) -> isInProsSection = false
-            line.isNotBlank() -> if (isInProsSection) prosList.add(line) else consList.add(line)
+            formattedLine.contains(PROS, true) -> isInProsSection = true
+            formattedLine.contains(CONS, true) -> isInProsSection = false
+            formattedLine.isNotBlank() -> if (isInProsSection) prosList.add(formattedLine) else consList.add(formattedLine)
         }
     }
 


### PR DESCRIPTION
Fixes #41 

This pull request includes a small improvement to the `formatCarReviewResponse` function in `Utilities.kt`. The change ensures that any backslashes (`) in the input lines are removed before processing, improving the handling of special characters in car review text.

Added logic to strip backslashes from lines in the `carReview` input before evaluating them for "pros" or "cons" sections.