### PR TITLE
Changing java compatibility to 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,11 +36,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
Resolves #66 

This pull request updates the Java and Kotlin compatibility versions in the `app/build.gradle.kts` file to align with modern standards and improve compatibility with newer language features.

Build configuration updates:

* Updated `sourceCompatibility` and `targetCompatibility` in the `compileOptions` block from `JavaVersion.VERSION_1_8` to `JavaVersion.VERSION_17`.
* Updated the `jvmTarget` in the `kotlinOptions` block from `"1.8"` to `"17"`.