### PR TITLE
Adding publish action script

### DIFF
--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -16,9 +16,11 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set Up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
+          cache: gradle
 
       - name: Change wrapper permissions
         run: chmod +x ./gradlew


### PR DESCRIPTION
Resolves #73 

This pull request introduces a new GitHub Actions workflow to automate the publishing of the Android app to the Google Play Store. The workflow is triggered after a successful run of the "Android Build" workflow on release branches and handles both the success and failure cases for publishing.

Workflow automation for Android publishing:

* Added `.github/workflows/android_publish.yml` to automate publishing the Android app to the Play Store upon successful completion of the "Android Build" workflow on release branches. The workflow includes steps for checking out the code, setting up the JDK, building and signing the release bundle, and deploying it to the Play Store, with appropriate handling for both success and failure scenarios.