### PR TITLE
CarIdentifier correcting calls to be inside of a launched effect

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/screen/CarDetailsScreen.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/screen/CarDetailsScreen.kt
@@ -54,20 +54,19 @@ fun CarDetailsScreen(
                 tabIndex = newTabIndex
             }
 
-            LaunchedEffect(tabIndex) {
-                when (tabIndex) {
-                    TAB_AI_INDEX -> carViewModel.getCarReview()
-                    TAB_TIRE_PRESSURE_INDEX -> carViewModel.getTirePressure()
-                }
-            }
-
             when (tabIndex) {
                 TAB_DETAILS_INDEX -> Details(carViewModel)
                 TAB_REVIEWS_INDEX -> Reviews(carViewModel)
                 TAB_AI_INDEX -> {
+                    LaunchedEffect(tabIndex) {
+                        carViewModel.getCarReview()
+                    }
                     Advice(carViewModel)
                 }
                 TAB_TIRE_PRESSURE_INDEX -> {
+                    LaunchedEffect(tabIndex) {
+                        carViewModel.getTirePressure()
+                    }
                     TirePressureScreen(carViewModel)
                 }
             }


### PR DESCRIPTION
Resolves #96 

This pull request refactors how side effects are triggered when switching tabs in the `CarDetailsScreen`. Instead of launching effects for multiple tabs in a single block, each tab that requires data fetching now has its own dedicated `LaunchedEffect` block, making the code clearer and more maintainable.

**Refactoring of tab side effects:**

* Moved the `LaunchedEffect` calls for `getCarReview()` and `getTirePressure()` into their respective tab branches, so that each effect is only triggered when its tab is selected, improving clarity and reducing unnecessary triggers.