### PR TITLE
CarIdentifier refactoring class to use flow instead of state

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/data/network/ConnectivityObserver.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/data/network/ConnectivityObserver.kt
@@ -19,6 +19,14 @@ class ConnectivityObserver(context: Context) {
     val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
 
     private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            val capabilities = connectivityManager?.getNetworkCapabilities(network)
+            _isConnected.value = capabilities?.hasCapability(
+                NetworkCapabilities.NET_CAPABILITY_VALIDATED,
+            ) ?: false
+        }
+
         override fun onLost(network: Network) {
             super.onLost(network)
             _isConnected.value = false
@@ -34,10 +42,9 @@ class ConnectivityObserver(context: Context) {
             networkCapabilities: NetworkCapabilities,
         ) {
             super.onCapabilitiesChanged(network, networkCapabilities)
-            val connected = networkCapabilities.hasCapability(
+            _isConnected.value = networkCapabilities.hasCapability(
                 NetworkCapabilities.NET_CAPABILITY_VALIDATED,
             )
-            _isConnected.value = connected
         }
     }
 


### PR DESCRIPTION
Fixes #105 

This pull request refactors the way network connectivity state is managed in the `ConnectivityObserver` class. The main change is moving from Compose's `MutableState` to Kotlin's `StateFlow` for tracking and exposing network connectivity, making the code more suitable for use outside of Compose and improving its reactivity and testability.

**Refactor connectivity state management:**

* Replaced `MutableState<Boolean>` and `mutableStateOf` with `MutableStateFlow<Boolean>` and exposed it as a read-only `StateFlow<Boolean>` in `ConnectivityObserver`, allowing better interoperability with coroutines and non-Compose consumers. 
* Updated all assignments and reads of the connectivity state to use `_isConnected.value` instead of `isConnected.value`, reflecting the new `StateFlow`-based implementation.