### PR TITLE
Feature/vin number

### DIFF
--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -144,7 +144,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             Icons.Default.Check,
-            contentDescription = "Check Icon",
+            contentDescription = null,
             tint = Color(0, 0, 0),
         )
     }
@@ -157,7 +157,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_key_icon),
-            "Key Icon",
+            contentDescription = null,
             tint = colorResource(R.color.yellow),
         )
     }
@@ -170,7 +170,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_fuel_type),
-            "Fuel Icon",
+            contentDescription = null,
             tint = colorResource(R.color.blue),
         )
     }
@@ -183,7 +183,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_shield),
-            "Safety Icon",
+            contentDescription = null,
             tint = colorResource(R.color.green),
         )
     }
@@ -196,7 +196,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_car_alert),
-            "Pollution Icon",
+            contentDescription = null,
             tint = colorResource(R.color.red),
         )
     }
@@ -209,7 +209,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_palette),
-            "Palette Icon",
+            contentDescription = null,
             tint = colorResource(R.color.brown),
         )
     }
@@ -222,7 +222,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_road),
-            "Road Icon",
+            contentDescription = null,
             tint = colorResource(R.color.black),
         )
     }
@@ -235,7 +235,7 @@ fun CarInformation(details: CarDetails) {
     ) {
         Icon(
             painterResource(id = R.drawable.ic_fact_check),
-            "Frame Icon",
+            contentDescription = null,
             tint = colorResource(R.color.purple_700),
         )
     }

--- a/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
+++ b/app/src/main/java/com/tomerpacific/caridentifier/composable/CarInformation.kt
@@ -226,4 +226,17 @@ fun CarInformation(details: CarDetails) {
             tint = colorResource(R.color.black),
         )
     }
+
+    CarDetailWithIcon(
+        iconId = "frameIcon",
+        labelText = stringResource(R.string.frame_number),
+        content = details.frameNumber,
+        tooltipDescription = stringResource(R.string.frame_number_tooltip_explanation),
+    ) {
+        Icon(
+            painterResource(id = R.drawable.ic_fact_check),
+            "Frame Icon",
+            tint = colorResource(R.color.purple_700),
+        )
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -22,6 +22,7 @@
     <string name="air_pollution_rating">Air pollution rating:</string>
     <string name="car_color">Color:</string>
     <string name="first_time_on_road">First time on the road:</string>
+    <string name="frame_number">VIN:</string>
     <string name="camera_permission_disclaimer">You need to allow camera permissions through the Settings screen</string>
     <string name="camera_permission_clarification">Camera permission is needed to scan license plate</string>
     <string name="amount_of_digits_in_license_plate">Please enter a 7 or 8 digit license plate number</string>
@@ -38,6 +39,7 @@
     <string name="air_pollution_rating_tooltip_explanation">Displays the air pollution rating of the car, which is a score out of 15</string>
     <string name="car_color_tooltip_explanation">Displays the color of the car</string>
     <string name="first_time_on_road_tooltip_explanation">Displays the date when the car was first registered to be on the road</string>
+    <string name="frame_number_tooltip_explanation">Displays the car\'s chassis number (VIN)</string>
     <string name="no_tire_pressure_data_for_car_error_msg">No tire pressure data available for this car.</string>
     <string name="tire_pressure">Tire Pressure</string>
     <string name="front_tire_psi">Front Tire PSI:</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -22,7 +22,7 @@
     <string name="air_pollution_rating">Air pollution rating:</string>
     <string name="car_color">Color:</string>
     <string name="first_time_on_road">First time on the road:</string>
-    <string name="frame_number">VIN:</string>
+    <string name="frame_number">Vehicle Identification Number (VIN):</string>
     <string name="camera_permission_disclaimer">You need to allow camera permissions through the Settings screen</string>
     <string name="camera_permission_clarification">Camera permission is needed to scan license plate</string>
     <string name="amount_of_digits_in_license_plate">Please enter a 7 or 8 digit license plate number</string>
@@ -39,7 +39,7 @@
     <string name="air_pollution_rating_tooltip_explanation">Displays the air pollution rating of the car, which is a score out of 15</string>
     <string name="car_color_tooltip_explanation">Displays the color of the car</string>
     <string name="first_time_on_road_tooltip_explanation">Displays the date when the car was first registered to be on the road</string>
-    <string name="frame_number_tooltip_explanation">Displays the car\'s chassis number (VIN)</string>
+    <string name="frame_number_tooltip_explanation">Displays the vehicle identification number (VIN)</string>
     <string name="no_tire_pressure_data_for_car_error_msg">No tire pressure data available for this car.</string>
     <string name="tire_pressure">Tire Pressure</string>
     <string name="front_tire_psi">Front Tire PSI:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="air_pollution_rating">רמת זיהום אוויר:</string>
     <string name="car_color">צבע:</string>
     <string name="first_time_on_road">עלה לכביש:</string>
+    <string name="frame_number">מספר שילדה:</string>
     <string name="camera_permission_disclaimer">יש צורך לתת הרשאות למצלמה דרך מסך ההגדרות</string>
     <string name="camera_permission_clarification">צריך לאשר הרשאה למצלמה כדי לסרוק לוחית רישוי</string>
     <string name="amount_of_digits_in_license_plate">הכנס מספר לוחית רישוי בן 7 או 8 ספרות</string>
@@ -37,6 +38,7 @@
     <string name="air_pollution_rating_tooltip_explanation">מציג את דירוג זיהום האוויר של הרכב, שזהו מספר עד 15</string>
     <string name="car_color_tooltip_explanation">מציג את צבע הרכב</string>
     <string name="first_time_on_road_tooltip_explanation">מציג את התאריך שבו הרכב נרשם לראשונה לעלות על הכביש</string>
+    <string name="frame_number_tooltip_explanation">מציג את מספר השילדה של הרכב (VIN)</string>
     <string name="no_tire_pressure_data_for_car_error_msg">לא נמצא מידע על לחץ אוויר בצמיגים עבור רכב זה.</string>
     <string name="tire_pressure">לחץ אוויר בצמיגים</string>
     <string name="front_tire_psi">לחץ אוויר בצמיג קדמי:</string>


### PR DESCRIPTION
Resolves #115 

This pull request adds support for displaying the car's frame number (VIN) in the car information view, including localized labels and tooltips in both English and Hebrew. The most important changes are:

**UI Enhancement:**

* Added a new `CarDetailWithIcon` component to display the frame number (VIN) with an associated icon and tooltip in the `CarInformation` composable.

**Localization:**

* Added the string resource for the frame number label (`frame_number`) in both English and Hebrew string resource files. [[1]](diffhunk://#diff-74d79d9fdeb4d943ff32ec1d9f6852280ede2ae497809f1cbba32a8ce63fbf32R25) [[2]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R24)
* Added the string resource for the frame number tooltip explanation (`frame_number_tooltip_explanation`) in both English and Hebrew string resource files.